### PR TITLE
Fixed typo in relationships $hasMany example. Changed 'key' to 'keys'.

### DIFF
--- a/en/working-with-data/relationships.wiki
+++ b/en/working-with-data/relationships.wiki
@@ -31,7 +31,7 @@ This simple declaration relies on convention, and is the functional equivalent t
 class Categories extends \lithium\data\Model {
 	public $hasMany = array('Products' => array(
 		'class'      => 'Products',
-		'key'        => 'category_id',
+		'keys'       => 'category_id',
 		'conditions' => array(),
 		'fields'     => array(),
 		'order'      => null,


### PR DESCRIPTION
It took me a little time to figure out that `'key' => 'category_id'` should be `'keys' => 'category_id'`, this will help people follow the manual with ease.
