### PR TITLE
Added litespeed configuration docs

### DIFF
--- a/config/docs/index.json
+++ b/config/docs/index.json
@@ -36,6 +36,7 @@
 							"configuration/servers/cherokee.wiki": { "title": "Cherokee" },
 							"configuration/servers/iis.wiki": { "title": "Internet Information Services (IIS)" },
 							"configuration/servers/lighttpd.wiki": { "title": "LigHTTPD" },
+							"configuration/servers/litespeed.wiki": { "title": "Litespeed" },
 							"configuration/servers/nginx.wiki" : { "title": "Nginx" }
 						}
 					},

--- a/en/configuration/servers/litespeed.wiki
+++ b/en/configuration/servers/litespeed.wiki
@@ -1,0 +1,42 @@
+# Lithium on Litespeed
+
+## Basic Setup
+
+In order to provide Lithium applications with clean URLs, Lithium ships with a set of `.htaccess` files for use with Apache, which will handle URL rewriting.  Litespeed supports `.htaccess` files, so it should work similar to Apache.
+
+Point Litespeed's Document Root to your application's `webroot` directory, which contains the `.htaccess` file with the rewrite rules.
+
+## Production Setup
+
+In production, it is recommended that you set `Allow Override` to `None` and instead place the rewrite rules in the `Rewrite` section of your Virtual Host in Litespeed's control panel.
+
+In the `Rewrite` section, set `Enable Rewrite` to `Yes` and paste the following into the `Rewrite Rules` section:
+
+{{{
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !favicon.ico$
+RewriteRule . index.php [QSA,L]
+}}}
+
+Note: the `?url=$1` appended to the rewritten url in the `.htaccess` and Apache config examples is unnecessary.  Litespeed sets the appropriate environment vars so Lithium can determine the requested path without needing to add a var to the query string.
+
+## Path Issue and Fix
+
+In order to determine the correct base url path for the app and for assets like scripts, css, and images, Lithium first looks to the `$_SERVER['PHP_SELF']` server/environment variable.  The lsapi used by Litespeed to interact with PHP seems to set `$_SERVER['PHP_SELF']` to the `REQUEST_URI` rather than the actual PHP file that is handling the request.  This causes Lithium to set the base path incorrectly.  To work around the issue, add the following to the top of your app's `config/bootstrap.php` file:
+
+{{{
+/** fix rewrite issue with Litespeed **/
+$_SERVER['PHP_SELF'] = str_replace('\\', '/', str_replace(
+	$_SERVER['DOCUMENT_ROOT'], '', $_SERVER['SCRIPT_FILENAME']
+));
+$_ENV['PHP_SELF'] = $_SERVER['PHP_SELF'];
+}}}
+
+See the following docs for more info on how the base path and other environment values are determined by Lithium:
+
+* [http://lithify.me/docs/lithium/action/Request::_base()](http://lithify.me/docs/lithium/action/Request::_base)
+* [http://lithify.me/docs/lithium/action/Request::env()](http://lithify.me/docs/lithium/action/Request::env)
+* [http://lithify.me/docs/lithium/action/Request::_init()](http://lithify.me/docs/lithium/action/Request::_init)
+
+


### PR DESCRIPTION
We use Litespeed web servers (although have been slowly moving to nginx).  I added a new section to the manual: configuration > servers > Litespeed.  It's similar to Apache, but there's a weird issue with PHP_SELF when using Litespeed where it has the REQUEST_URI instead of the actual script filename.  So I put info about my workaround for this issue in the docs.

Also -- which systems need the `?url=$1` in the rewrite rule?  I think Lithium can figure it out correctly from the environment/server vars.  I was just seeing that this `url` var is placed in the \lithium\action\Request query array and then echoed out when running $request->to('url') which seems less than desirable.  I took it out in the Litespeed rewrite rules since it's definitely not needed there.

Hope you guys are well.
-Rob
