### PR TITLE
Getting Started - Advanced Setup - defining lithium separate of app

### DIFF
--- a/en/getting-started/installation.wiki
+++ b/en/getting-started/installation.wiki
@@ -32,7 +32,7 @@ The two applications mentioned aren't complete copies of the Lithium codebase: t
 First, you'll want to create two virtual hosts for the applications on the system. Once those are in place, each application's bootstrap will need to be informed of where the Lithium libraries are. Adjust both application's `/config/bootstrap/libraries.php` file like so:
 
 {{{
-define('LITHIUM_LIBRARY_PATH', dirname('/usr/local/lib/lithium');
+define('LITHIUM_LIBRARY_PATH', dirname('/usr/local/lib/lithium'));
 }}}
 
 ## Pedal to the Metal


### PR DESCRIPTION
Just getting started with Lithium and going through the manuals, when I tried separating lithium from the app in the advanced setup part by adding a `define()` line to `config/bootstrap.php`

I got an error saying it was defined in the `config/bootstrap/libraries.php`, so I modified the path there, and everything worked.

It makes sense to me, but I'm still very new with the code.  Hope it helps :)
