### PR TITLE
Not promoting the ?url= behavior in the Apache documentation.

### DIFF
--- a/en/configuration/servers/apache.wiki
+++ b/en/configuration/servers/apache.wiki
@@ -32,7 +32,7 @@ In production, it is recommended that you set `AllowOverride` to `None` and inst
 		RewriteCond %{REQUEST_FILENAME} !-d
 		RewriteCond %{REQUEST_FILENAME} !-f
 		RewriteCond %{REQUEST_FILENAME} !favicon.ico$
-		RewriteRule ^(.*)$ index.php?url=$1 [QSA,L]
+		RewriteRule ^ index.php [QSA,L]
 	</Directory>
 </VirtualHost>
 }}}


### PR DESCRIPTION
Following the tickets I've open in lithium and framework, here is the documentation one. It updates the Apache `mod_rewrite` configuration to use the `REQUEST_URI` way of dealing with cool URIs. The links below are containing much more details:
- https://github.com/UnionOfRAD/lithium/issues/340
- https://github.com/UnionOfRAD/framework/pull/14

Thanks!
