### PR TITLE
Bug fixed in  handling-http-requests/helpers.wiki

### DIFF
--- a/en/handling-http-requests/helpers.wiki
+++ b/en/handling-http-requests/helpers.wiki
@@ -44,7 +44,7 @@ namespace app\extensions\helper;
 
 class AwesomeHtml extends \lithium\template\Helper {
 
-	private $_strings = array(
+	protected $_strings = array(
 		'awesome'    => '<a class="awesome" href="{:url}">{:title}</a>',
 		'super_cool' => '<span class="super"><a class="cool" href="{:url}">{:title}</a></span>',
 	);
@@ -62,7 +62,7 @@ Once this has been setup, we can use the new helper as we would any of the core 
 
 {{{<p>
 	You should really check out
-	<?=$this->awesomeLink->create('Lithium', 'http://lithify.me', array(
+	<?=$this->awesomeHtml->link('Lithium', 'http://lithify.me', array(
 		'type' => 'super_cool'
 	)) ?>
 </p>}}}


### PR DESCRIPTION
The example code contained a couple of typos, one where the $_strings variable in the helper was private, so inaccessible by the parent _render function, and one in the template, where the wrong convention was used to access the link function.  
