### PR TITLE
Updates domain to li3.me

### DIFF
--- a/en/appendices/readme.md
+++ b/en/appendices/readme.md
@@ -2,7 +2,7 @@
 
 ### PHP short tags in templates? Haven't those been deprecated for, like, ever?
 
-You may have noticed that Lithium templates use PHP short tags (i.e. `<?=`). Don't worry though, these aren't actually interpreted by PHP. Instead, Lithium uses an internal template compiler to change these tags into full `<?php echo ... ?>` statements, with the added benefit of automatic content escaping, so you don't have to think about XSS attacks. Also, the compiler is smart enough to recognize content coming from helpers, etc., so it won't double-escape. For more info, check out the documentation on [the templating system](http://lithify.me/docs/lithium/template).
+You may have noticed that Lithium templates use PHP short tags (i.e. `<?=`). Don't worry though, these aren't actually interpreted by PHP. Instead, Lithium uses an internal template compiler to change these tags into full `<?php echo ... ?>` statements, with the added benefit of automatic content escaping, so you don't have to think about XSS attacks. Also, the compiler is smart enough to recognize content coming from helpers, etc., so it won't double-escape. For more info, check out the documentation on [the templating system](http://li3.me/docs/lithium/template).
 
 ### You guys use statics all over the place. Aren't those really hard to test?
 
@@ -22,7 +22,7 @@ The essential problem with this is that there's often no way to determine at any
 
 Fortunately, all static classes in Lithium are either composed of _referentially transparent_ methods, or methods whose usage patterns are oriented around _immutability_. Some examples of referentially transparent methods are `lithium\util\String::insert()`, which inserts values into a template string, or `lithium\util\Inflector::camelize()`, which produces a version of a word or phrase. These functions have no external side-effects, and produce predictable output based on their parameters.
 
-Examples of immutable static classes would be any class extends [`Adaptable`](http://lithify.me/docs/lithium/core/Adaptable), i.e. `Cache`, `Connections`, etc. These classes model and provide access to system-level resources such as database connections, user sessions, and caching configurations. These classes are configured with information on how to access and operate on their respective resources using the `config()` method of each class. This happens once and only once, during the application's bootstrap process. Subsequent access to those classes (i.e. through the `adapter()` method) always returns the same adapter instance with the same attributes. This avoids the problem of having our application's state change out from under us.
+Examples of immutable static classes would be any class extends [`Adaptable`](http://li3.me/docs/lithium/core/Adaptable), i.e. `Cache`, `Connections`, etc. These classes model and provide access to system-level resources such as database connections, user sessions, and caching configurations. These classes are configured with information on how to access and operate on their respective resources using the `config()` method of each class. This happens once and only once, during the application's bootstrap process. Subsequent access to those classes (i.e. through the `adapter()` method) always returns the same adapter instance with the same attributes. This avoids the problem of having our application's state change out from under us.
 
 The other issue often referred to when testing statics is that they're difficult to mock, or replace dependencies. Consider the following:
 

--- a/en/appendices/using-in-other-applications.md
+++ b/en/appendices/using-in-other-applications.md
@@ -25,4 +25,4 @@ This correctly locates your app directory in Lithium's class loader, and suppres
 
 ## Defining data connections
 
-If you plan on using Lithium's data layer, you need to create `connections.php` inside `LITHIUM_APP_PATH/config`.  If you are defining your connections dynamically, this file can be empty. By convention, however, this file is used to configure your database and web service connections.  See [`lithium\data\Connections`](http://lithify.me/docs/lithium/data/Connections) for more information on how to do this.
+If you plan on using Lithium's data layer, you need to create `connections.php` inside `LITHIUM_APP_PATH/config`.  If you are defining your connections dynamically, this file can be empty. By convention, however, this file is used to configure your database and web service connections.  See [`lithium\data\Connections`](http://li3.me/docs/lithium/data/Connections) for more information on how to do this.

--- a/en/auth/simple-authentication.md
+++ b/en/auth/simple-authentication.md
@@ -167,6 +167,6 @@ Router::connect('/logout', 'Sessions::delete');
 
 If you'd like to get under the hood and see how Lithium handles password hashing, auth queries & session writes, etc., check out the API documentation for the following:
 
- - [The `Auth` class](http://lithify.me/docs/lithium/security/Auth)
- - [The `Form` auth adapter](http://lithify.me/docs/lithium/security/auth/adapter/Form)
- - [The `Password` class](http://lithify.me/docs/lithium/security/Password)
+ - [The `Auth` class](http://li3.me/docs/lithium/security/Auth)
+ - [The `Form` auth adapter](http://li3.me/docs/lithium/security/auth/adapter/Form)
+ - [The `Password` class](http://li3.me/docs/lithium/security/Password)

--- a/en/configuration/servers/litespeed.md
+++ b/en/configuration/servers/litespeed.md
@@ -35,8 +35,8 @@ $_ENV['PHP_SELF'] = $_SERVER['PHP_SELF'];
 
 See the following docs for more info on how the base path and other environment values are determined by Lithium:
 
-* [http://lithify.me/docs/lithium/action/Request::_base()](http://lithify.me/docs/lithium/action/Request::_base)
-* [http://lithify.me/docs/lithium/action/Request::env()](http://lithify.me/docs/lithium/action/Request::env)
-* [http://lithify.me/docs/lithium/action/Request::_init()](http://lithify.me/docs/lithium/action/Request::_init)
+* [http://li3.me/docs/lithium/action/Request::_base()](http://li3.me/docs/lithium/action/Request::_base)
+* [http://li3.me/docs/lithium/action/Request::env()](http://li3.me/docs/lithium/action/Request::env)
+* [http://li3.me/docs/lithium/action/Request::_init()](http://li3.me/docs/lithium/action/Request::_init)
 
 

--- a/en/extending-lithium/plugins.md
+++ b/en/extending-lithium/plugins.md
@@ -1,18 +1,18 @@
 # Creating a Lithium Plugin
 
-If you've written a piece of functionality that you want to share among multiple applications, or [distribute within the Lithium community](http://lab.lithify.me/), you'll want to create a _plugin_. The good news is, if you've already created a Lithium application, you're more than half way there.
+If you've written a piece of functionality that you want to share among multiple applications, or [distribute within the Lithium community](http://lab.li3.me/), you'll want to create a _plugin_. The good news is, if you've already created a Lithium application, you're more than half way there.
 
-First, to understand how Lithium deals with plugins, it's important to understand how it deals with _libraries_, so make sure you've read "[Working with External Libraries](http://lithify.me/docs/manual/01_getting_started/external_libs)". In Lithium, everything is a library, including the Lithium core, other frameworks, your application, and of course, plugins. By convention, plugins are simply libraries that conform to the same organizational conventions as a Lithium application.
+First, to understand how Lithium deals with plugins, it's important to understand how it deals with _libraries_, so make sure you've read "[Working with External Libraries](http://li3.me/docs/manual/01_getting_started/external_libs)". In Lithium, everything is a library, including the Lithium core, other frameworks, your application, and of course, plugins. By convention, plugins are simply libraries that conform to the same organizational conventions as a Lithium application.
 
 ## Requirements
 
-While there are very few (really no) _hard_ requirements for Lithium plugins, there are several very strong recommendations. First and foremost is that you follow the namespacing standards outlined in the [`Libraries` class documentation](http://lithify.me/docs/lithium/core/Libraries). Second, your plugin should include a `config` directory containing a `bootstrap.php` file. Finally, as mentioned above, it's best to conform to the same directory structure as a Lithium application. And of course, classes must be namespaced accordingly, with the root namespace matching the name of the plugin. (An exception to this would be if you were using an organizational or vendor-level namespace within which your plugin lived, in which case the plugin's root namespace would look like `vendor\plugin_name`).
+While there are very few (really no) _hard_ requirements for Lithium plugins, there are several very strong recommendations. First and foremost is that you follow the namespacing standards outlined in the [`Libraries` class documentation](http://li3.me/docs/lithium/core/Libraries). Second, your plugin should include a `config` directory containing a `bootstrap.php` file. Finally, as mentioned above, it's best to conform to the same directory structure as a Lithium application. And of course, classes must be namespaced accordingly, with the root namespace matching the name of the plugin. (An exception to this would be if you were using an organizational or vendor-level namespace within which your plugin lived, in which case the plugin's root namespace would look like `vendor\plugin_name`).
 
 ## What Can Plugins Include?
 
 Because Lithium treats everything as libraries, and because all libraries are essentially on the same playing field, a plugin can include anything. Any type of class or resource that could be included in the Lithium core or in an application can be included in a plugin. This includes models, controllers, helpers, adapters, generic classes, even custom routes and web assets.
 
-Common examples of things to include in plugins are adapters for cache engines, databases or web services, or a collection of models to share between multiple applications that use the same data. Other plugins introduce new classes with new functionality which can have their own types of adapters, such as the [`li3_access` plugin](https://github.com/tmaiaroto/li3_access), which adds access control support. Some plugins, like [`li3_twig`](http://dev.lithify.me/li3_twig), [`li3_doctrine`](http://dev.lithify.me/li3_doctrine) and [`li3_pdf`](http://dev.lithify.me/li3_pdf), wrap other libraries to provide tight integration with Lithium.
+Common examples of things to include in plugins are adapters for cache engines, databases or web services, or a collection of models to share between multiple applications that use the same data. Other plugins introduce new classes with new functionality which can have their own types of adapters, such as the [`li3_access` plugin](https://github.com/tmaiaroto/li3_access), which adds access control support. Some plugins, like [`li3_twig`](http://dev.li3.me/li3_twig), [`li3_doctrine`](http://dev.li3.me/li3_doctrine) and [`li3_pdf`](http://dev.li3.me/li3_pdf), wrap other libraries to provide tight integration with Lithium.
 
 ## Creating Your First Plugin
 
@@ -26,7 +26,7 @@ This creates a new plugin from Lithium's default plugin template. When completed
 
 ## Installing and Configuring
 
-As with other libraries, plugins are installed in your local or system `libraries` directory by cloning, symlinking, etc. (Again, see "[Working with External Libraries](http://lithify.me/docs/manual/01_getting_started/external_libs)"). An important thing to know when developing plugins is that when your library is registered through [`Libraries::add()`](http://lithify.me/docs/lithium/core/Libraries::add(), it can also be configured with custom settings.
+As with other libraries, plugins are installed in your local or system `libraries` directory by cloning, symlinking, etc. (Again, see "[Working with External Libraries](http://li3.me/docs/manual/01_getting_started/external_libs)"). An important thing to know when developing plugins is that when your library is registered through [`Libraries::add()`](http://li3.me/docs/lithium/core/Libraries::add(), it can also be configured with custom settings.
 
 While `add()`'s `$config` parameter specifies several default configuration settings, it is also possible to pass any other arbitrary information that you may wish to use in your plugin. This data can then be retrieved within your plugin by calling `Libraries::get('plugin_name')` or `Libraries::get('plugin_name', 'key')`.
 

--- a/en/extending-lithium/third-party-libraries.md
+++ b/en/extending-lithium/third-party-libraries.md
@@ -4,7 +4,7 @@ Lithium applications are made up of collections of _libraries_. A library is any
 
 ## Basics
 
-Libraries are managed by the `lithium\core\Libraries` class, which handles auto-loading, service location, and introspecting available classes. When loading classes, Lithium assumes a [PSR-0 compatible](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md) class mapping structure. For more information, see the [documentation for the `Libraries` class](http://lithify.me/docs/lithium/core/Libraries).
+Libraries are managed by the `lithium\core\Libraries` class, which handles auto-loading, service location, and introspecting available classes. When loading classes, Lithium assumes a [PSR-0 compatible](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md) class mapping structure. For more information, see the [documentation for the `Libraries` class](http://li3.me/docs/lithium/core/Libraries).
 
 The default Lithium distribution ships with two `libraries` directories: one located at the root of the distribution, and one located in the `app` folder (or any application you generate with the console tooling). Libraries can be installed into either of these directories, and both are used interchangeably throughout this guide. The global `libraries` directory is intended for libraries which are shared across multiple applications, whereas the local directory is intended for application-specific ones, and will override the global directory in the event of a conflict.
 
@@ -16,7 +16,7 @@ Generally, there are two ways in which a library can be packaged and distributed
 
 The alternative approach is for a distribution to contain its library in a subdirectory. Examples would be the [Zend Framework](https://github.com/zendframework/zf2/tree/master/library) or [Symfony 2](https://github.com/symfony/symfony/tree/master/src).
 
-In the first case, installation is as simple as downloading (or cloning, or adding as a submodule) the library you wish to use into your `libraries` directory. When registering the library with [`Libraries::add()`](http://lithify.me/docs/lithium/core/Libraries::add(), no other configuration is necessary, since Lithium knows where to look for it, and how to map its classes.
+In the first case, installation is as simple as downloading (or cloning, or adding as a submodule) the library you wish to use into your `libraries` directory. When registering the library with [`Libraries::add()`](http://li3.me/docs/lithium/core/Libraries::add(), no other configuration is necessary, since Lithium knows where to look for it, and how to map its classes.
 
 Since that's not possible for libraries in the second case, we recommend an alternative installation: download (clone, etc.) the distribution to `libraries/_source`, and symlink the root of the library source into the `libraries` directory.
 
@@ -152,7 +152,7 @@ class EmailController extends \lithium\action\Controller {
 
 Some legacy vendor libraries have no consistent class-to-file mapping scheme whatsoever. These libraries must be mapped by hand. Below is an example of a small library (TCPDF), containing just a few files.
 
- _Note_: For larger libraries, generating the map by hand can be tedious. Check out [the `Inspector` class](http://lithify.me/docs/lithium/analysis/Inspector), which can be used to introspect classes and files to generate a map automatically.
+ _Note_: For larger libraries, generating the map by hand can be tedious. Check out [the `Inspector` class](http://li3.me/docs/lithium/analysis/Inspector), which can be used to introspect classes and files to generate a map automatically.
 
 {{{
 Libraries::add('tcpdf', array(

--- a/en/getting-started/installation.md
+++ b/en/getting-started/installation.md
@@ -4,7 +4,7 @@
 
 This easiest way to get a fresh copy of Lithium is by downloading an archive from our website. You can view and download versions here:
 
-	http://dev.lithify.me/lithium/versions
+	http://dev.li3.me/lithium/versions
 	
 Under the hood, Lithium is actually separated in two different repositories. One is called `framework` and the other one `lithium`. The `framework` repository holds everything you need to 
 instantly bootstrap your application, while the `lithium` repository holds the Lithium core. This way you can reuse the Lithium core for other projects or just include some libraries if you 

--- a/en/handling-http-requests/helpers.md
+++ b/en/handling-http-requests/helpers.md
@@ -7,7 +7,7 @@ Lithium helpers take the concept of elements a bit further, and create a place t
 Helper usage in Lithium is simple because helpers are lazy-loaded by the renderer. To use a helper in the view layer, just reference it as a property of the renderer:
 
 {{{<p>
-	Here is a <?=$this->html->link('link', 'http://lithify.me') ?> you'll all enjoy.
+	Here is a <?=$this->html->link('link', 'http://li3.me') ?> you'll all enjoy.
 </p>}}}
 
 This approach means you won't have to declare which helpers you're planning on using. Ever. This also means that things aren't loaded up unless (and until!) you're actually using them.
@@ -62,7 +62,7 @@ Once this has been setup, we can use the new helper as we would any of the core 
 
 {{{<p>
 	You should really check out
-	<?=$this->awesomeHtml->link('Lithium', 'http://lithify.me', array(
+	<?=$this->awesomeHtml->link('Lithium', 'http://li3.me', array(
 		'type' => 'super_cool'
 	)) ?>
 </p>}}}

--- a/en/handling-http-requests/views.md
+++ b/en/handling-http-requests/views.md
@@ -142,7 +142,7 @@ If you're in the view layer, `$this` refers to the current `Renderer` adapter. R
    // Returns the URL for the matching route, e.g. '/posts/view/13'
  }}}
 
- The `url()` output handler is a friendly wrapper for [`Router::match()`](http://lithify.me/docs/lithium/net/http/Router::match), and automatically passes some contextual parameters behind-the-scenes.
+ The `url()` output handler is a friendly wrapper for [`Router::match()`](http://li3.me/docs/lithium/net/http/Router::match), and automatically passes some contextual parameters behind-the-scenes.
 
  * `$this->path()`: This handler generates asset paths to physical files. This is especially helpful for applications that will live at different parts of the domain during its lifecycle.
 
@@ -155,7 +155,7 @@ If you're in the view layer, `$this` refers to the current `Renderer` adapter. R
    // If we're running at http://example.com/, this will return:
    // /videos/funny_cats.flv
  }}}
- Like `url()`, this handler is a wrapper for another class method, [`Media::asset()`](http://lithify.me/docs/lithium/net/http/Media::asset). Therefore, options that this method accepts can be passed to `path()` as well. For example, if you want to verify that the asset exists before returning the path, you can do the following:
+ Like `url()`, this handler is a wrapper for another class method, [`Media::asset()`](http://li3.me/docs/lithium/net/http/Media::asset). Therefore, options that this method accepts can be passed to `path()` as well. For example, if you want to verify that the asset exists before returning the path, you can do the following:
 
  {{{
   // Returns the path if the file exists, otherwise false.
@@ -183,7 +183,7 @@ If you're in the view layer, `$this` refers to the current `Renderer` adapter. R
    <title>My Awesome Application: <?= $this->title(); ?></title>
  }}}
 
- * `$this->scripts()`: Prints out the scripts specified for the current template. Usually, this is used by the [`script()` method of the `Html` helper](http://lithify.me/docs/lithium/template/helper/Html::script) when the `'inline'` option is set to `false`. However, you can append tags manually as well:
+ * `$this->scripts()`: Prints out the scripts specified for the current template. Usually, this is used by the [`script()` method of the `Html` helper](http://li3.me/docs/lithium/template/helper/Html::script) when the `'inline'` option is set to `false`. However, you can append tags manually as well:
 
  {{{
    // In your view:
@@ -210,7 +210,7 @@ If you're in the view layer, `$this` refers to the current `Renderer` adapter. R
   <?php $this->scripts(ob_get_clean()); ?>
  }}}
 
- * `$this->styles()`: Much the same as `scripts()` above, the `styles()` handler acts as a repository for any page-specific style sheets to be included in the layout. While primarily used by the [`style()` method of the `Html` helper](http://lithify.me/docs/lithium/template/helper/Html::style) (again, see the `'inline'` option), it may be used manually as well:
+ * `$this->styles()`: Much the same as `scripts()` above, the `styles()` handler acts as a repository for any page-specific style sheets to be included in the layout. While primarily used by the [`style()` method of the `Html` helper](http://li3.me/docs/lithium/template/helper/Html::style) (again, see the `'inline'` option), it may be used manually as well:
 
  {{{
     // In your view:

--- a/en/lithium-basics/architecture.md
+++ b/en/lithium-basics/architecture.md
@@ -214,7 +214,7 @@ Custom view helpers are common need. These classes should extend `lithium\templa
 
 The `libraries` folder is meant to house entire Lithium applications—or plugins—that your main application makes use of. 
 
-Any plugins you download from the [ Laboratory](http://lab.lithify.me/), or pull down via the Library `li3` command should end up here.
+Any plugins you download from the [ Laboratory](http://lab.li3.me/), or pull down via the Library `li3` command should end up here.
 
 Third-party, non-Lithium libraries should be placed here as well. If you're integrating with Facebook, or using part of the Zend Framework in your application, place those files here as well.
 

--- a/en/lithium-basics/filters.md
+++ b/en/lithium-basics/filters.md
@@ -184,7 +184,7 @@ Filters::apply('blog\models\Posts', 'find', function($self, $params, $chain) {
 
 ## Creating Filter-able Logic
 
-If you're planning on creating and distributing your own code (hopefully via the [Lithium Laboratory](http://lab.lithify.me/), among other things) you might consider writing parts of your API to be filter-able. This allows other developers to take advantage of the powerful Lithium filter system, while at the same time helping you avoid writing extra callback methods or configuration options in your code.
+If you're planning on creating and distributing your own code (hopefully via the [Lithium Laboratory](http://lab.li3.me/), among other things) you might consider writing parts of your API to be filter-able. This allows other developers to take advantage of the powerful Lithium filter system, while at the same time helping you avoid writing extra callback methods or configuration options in your code.
 
 Let's imagine for a bit that you're creating a social media integration extension for Lithium. The library will connect to popular social networking sites to post or gather information. Since you're offering this to other developers to use in their applications, it'd be nice to enable filtering on some of the logic.
 

--- a/en/quality-code/coding-standards.md
+++ b/en/quality-code/coding-standards.md
@@ -26,7 +26,7 @@ Never use short open tags:
 
 	<?
 
-Well, unless you are in a view and want the variable data to be automatically escaped. See the Lithium [template namespace documentation](http://lithify.me/docs/lithium/template) for more information on this exception.
+Well, unless you are in a view and want the variable data to be automatically escaped. See the Lithium [template namespace documentation](http://li3.me/docs/lithium/template) for more information on this exception.
 
 	<?=$post->title;?>
 

--- a/en/quickstart/readme.md
+++ b/en/quickstart/readme.md
@@ -4,7 +4,7 @@ Thanks for trying out Lithium! This guide is meant for PHP users who are looking
 
 ## Setting Up the Lab
 
-First on the checklist is getting a fresh copy of Lithium. If you've not done this already, check out our [Getting Started](http://lithify.me/docs/manual/getting-started/installation.wiki) guide. Make sure to follow each of the steps in the guide carefully.
+First on the checklist is getting a fresh copy of Lithium. If you've not done this already, check out our [Getting Started](http://li3.me/docs/manual/getting-started/installation.wiki) guide. Make sure to follow each of the steps in the guide carefully.
 
 Once you've got Lithium up and running, we'll need to get some sort of persistent storage layer in place. Traditionally this would be done using some sort of SQL database like MySQL. For this example however, we're going to use something a little different: MongoDB. Using a different setup will show you how flexible the framework is in using different engines.
 

--- a/en/working-with-data/creating-data-sources.md
+++ b/en/working-with-data/creating-data-sources.md
@@ -46,7 +46,7 @@ Focus on understanding the meaning behind these methods for now—we'll be imple
 
 Once models understand the basic shape for your data, the next step is facilitating communication between the data source and its associated models.
 
-In Lithium, models ask the data source questions through [`Query` objects](http://lithify.me/docs/lithium/data/model/Query), and the data source (typically) answers with one or more `Entity` objects, which are either a `Record` or a `Document`. For example, when a model is to find data, it packages up a `Query` object that contains structured data about what sort of information the model is asking for, in what order it expects it returned in, paging information, etc.
+In Lithium, models ask the data source questions through [`Query` objects](http://li3.me/docs/lithium/data/model/Query), and the data source (typically) answers with one or more `Entity` objects, which are either a `Record` or a `Document`. For example, when a model is to find data, it packages up a `Query` object that contains structured data about what sort of information the model is asking for, in what order it expects it returned in, paging information, etc.
 
 It passes this `Query` to the data source, which connects and authenticates to the data store. It inspects the query to see what the model needs, interacts with the underlying data store, and wraps the response data in some sort of `Entity`. If the response requires more than one `Entity`, it's usually wrapped up in a `Collection` like a `RecordSet` or `DocumentSet`.
 
@@ -54,7 +54,7 @@ Once the model has the `Entity` (or collection of entites), it can provide that 
 
 ## Example Data Source: GitHub Issues API
 
-Let's dive into a real-life example of creating a data source. For the remainder of this guide, we'll walk through the process of creating a new data source that connects to, authenticates with, and moves data to and from the GitHub API. Version 2 of the GitHub API is available via a simple RESTful interface that uses HTTP authentication. We'll be setting up a new data source, using the existing [`data\source\Http` base class](http://lithify.me/docs/lithium/data/source/Http) as a starting point.
+Let's dive into a real-life example of creating a data source. For the remainder of this guide, we'll walk through the process of creating a new data source that connects to, authenticates with, and moves data to and from the GitHub API. Version 2 of the GitHub API is available via a simple RESTful interface that uses HTTP authentication. We'll be setting up a new data source, using the existing [`data\source\Http` base class](http://li3.me/docs/lithium/data/source/Http) as a starting point.
 
 ### Setup
 
@@ -72,7 +72,7 @@ class GitHub extends \lithium\data\source\Http {
 
 This puts the class in the proper namespace, and imports some utility classes we'll be using later on.
 
- _A note on organization:_ Most data source adapters break down into a few basic _types_. For example, all relational databases are of the `database` type. They all work similarly, all share a common base class, and all live in `data\source\database` (in core), or `extensions\adapter\data\source\database` (in an application or plugin). Likewise with data sources that connect to databases or web services over HTTP. However, other data sources like [ `MongoDb`](http://lithify.me/docs/lithium/data/source/MongoDb) don't have a type. This distinction becomes important when configuring them, as seen below.
+ _A note on organization:_ Most data source adapters break down into a few basic _types_. For example, all relational databases are of the `database` type. They all work similarly, all share a common base class, and all live in `data\source\database` (in core), or `extensions\adapter\data\source\database` (in an application or plugin). Likewise with data sources that connect to databases or web services over HTTP. However, other data sources like [ `MongoDb`](http://li3.me/docs/lithium/data/source/MongoDb) don't have a type. This distinction becomes important when configuring them, as seen below.
 
 Now, let's create a connection that uses this new data source. Add a few lines to `config/bootstrap/connections.php`:
 

--- a/en/working-with-data/validation.md
+++ b/en/working-with-data/validation.md
@@ -34,7 +34,7 @@ class User extends lithium\data\Model {
 ?>
 }}}
 
-Note: for a complete list of built-in validation rules, see the `Validator` API: [http://lithify.me/docs/lithium/util/Validator](http://lithify.me/docs/lithium/util/Validator)
+Note: for a complete list of built-in validation rules, see the `Validator` API: [http://li3.me/docs/lithium/util/Validator](http://li3.me/docs/lithium/util/Validator)
 
 This initial example shows how rules are defined. First, each set of rules is keyed by the model field name. Each field is then assigned an array of rules, where the first value is the name of the rule, and the subsequent keys define additional information about each rule.
 

--- a/jp/00_quickstart/blog.md
+++ b/jp/00_quickstart/blog.md
@@ -4,7 +4,7 @@ Thanks for trying out Lithium! This guide is meant for PHP users who are looking
 
 ## Setting Up the Lab
 
-First on the checklist is getting a fresh copy of Lithium. If you've not done this already, check out our [Getting Started](http://dev.lithify.me/lithium/wiki/guides/installation) guide. Make sure to follow each of the steps in the guide carefully.
+First on the checklist is getting a fresh copy of Lithium. If you've not done this already, check out our [Getting Started](http://dev.li3.me/lithium/wiki/guides/installation) guide. Make sure to follow each of the steps in the guide carefully.
 
 Once you've got Lithium up and running, we'll need to get some sort of persistent storage layer in place. Traditionally this would be done using some sort of SQL database like MySQL. For this example however, we're going to use something a little different: MongoDB. Using a different setup will show you how flexible the framework is in using different engines.
 

--- a/jp/01_getting_started/01_installation.md
+++ b/jp/01_getting_started/01_installation.md
@@ -4,9 +4,9 @@
 
 This easiest way to get a fresh copy of Lithium is by downloading an archive from our website. You can view and download versions here:
 
-	http://dev.lithify.me/lithium/versions
+	http://dev.li3.me/lithium/versions
 
-Li3's source is also housed in a Git repo. If you'd like to clone a copy, start by creating a new account at [http://dev.lithify.me/users/add](http://dev.lithify.me/users/add). Once you've successfully created your new account, add your SSH key at [http://dev.lithify.me/users/account](http://dev.lithify.me/users/account). If you've never completed that process before, sometimes its as simple as typing in 'ssh-keygen' in a console.
+Li3's source is also housed in a Git repo. If you'd like to clone a copy, start by creating a new account at [http://dev.li3.me/users/add](http://dev.li3.me/users/add). Once you've successfully created your new account, add your SSH key at [http://dev.li3.me/users/account](http://dev.li3.me/users/account). If you've never completed that process before, sometimes its as simple as typing in 'ssh-keygen' in a console.
 
 	$ ssh-keygen
 
@@ -17,12 +17,12 @@ Li3's source is also housed in a Git repo. If you'd like to clone a copy, start 
 	Your identification has been saved in /Users/lithium/.ssh/id_rsa.
 	Your public key has been saved in /Users/lithium/.ssh/id_rsa.pub.
 
-Once the public key has been created, copy and paste it's contents into the `Ssh Keys` section of your account settings at dev.lithify.me.
+Once the public key has been created, copy and paste it's contents into the `Ssh Keys` section of your account settings at dev.li3.me.
 
 Now that your key has been set up, clone yourself a copy of Li3 inside of your web server's document root:
 
 	$ cd /path/to/docroot
-	$ git clone code@dev.lithify.me:lithium.git
+	$ git clone code@dev.li3.me:lithium.git
 
 	Initialize lithium/.git
 	Initialized empty Git repository in /path/to/docroot/lithium/.git/

--- a/jp/02_lithium_basics/00_architecture.md
+++ b/jp/02_lithium_basics/00_architecture.md
@@ -102,7 +102,7 @@ Custom view helpers are common need. These classes should extend `lithium\templa
 
 The `libraries` folder is meant to house entire Lithium applications—or plugins—that your main application makes use of. 
 
-Any plugins you download from the [ Laboratory](http://lab.lithify.me/), or pull down via the Library li3 command should end up here.
+Any plugins you download from the [ Laboratory](http://lab.li3.me/), or pull down via the Library li3 command should end up here.
 
 Third-party, non-Lithium libraries should be placed here as well. If you're integrating with Facebook, or using part of the Zend Framework in your application, place those files here as well.
 

--- a/jp/02_lithium_basics/02_filters.md
+++ b/jp/02_lithium_basics/02_filters.md
@@ -140,7 +140,7 @@ Connections::get('default')->applyFilter('_execute', function($self, $params, $c
 
 ## Creating Filter-able Logic
 
-If you're planning on creating and distributing your own code (hopefully via the [Lithium Laboratory](http://lab.lithify.me/), among other things) you might consider writing parts of your API to be filter-able. This allows other developers to take advantage of the powerful Lithium filter system, while at the same time helping you avoid writing extra callback methods or configuration options in your code.
+If you're planning on creating and distributing your own code (hopefully via the [Lithium Laboratory](http://lab.li3.me/), among other things) you might consider writing parts of your API to be filter-able. This allows other developers to take advantage of the powerful Lithium filter system, while at the same time helping you avoid writing extra callback methods or configuration options in your code.
 
 Let's imagine for a bit that you're creating a social media integration extension for Lithium. The library will connect to popular social networking sites to post or gather information. Since you're offering this to other developers to use in their applications, it'd be nice to enable filtering on some of the logic.
 


### PR DESCRIPTION
- Change domain referenced from lithify.me (currently unregistered as of 2014-01-04 and not resolving) to li3.me (currently resolving just fine)

It's possible I've got the wrong end of the stick, but the docs at http://li3.me/ still point to lithify.me

See also https://github.com/UnionOfRAD/li3_docs/pull/37
