### PR TITLE
Update example for skipping validation

### DIFF
--- a/en/models/validation.md
+++ b/en/models/validation.md
@@ -147,7 +147,7 @@ $post = Posts::create($data);
 
 if ($success = $post->validates()) {
 	// ...
-	$post->save(array('validate' => false));
+	$post->save(null, array('validate' => false));
 }
 ```
 


### PR DESCRIPTION
Skipping validation only seems to work if the options array is passed in as the second parameter.